### PR TITLE
Fix PYQ/quiz images: restore missing images + render them inline

### DIFF
--- a/src/__tests__/interleaveImages.test.ts
+++ b/src/__tests__/interleaveImages.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { interleaveImages } from "../lib/interleaveImages";
+
+const P = "para0\n\npara1\n\npara2\n\npara3\n\npara4\n\npara5\n\npara6"; // 7 paragraphs
+
+describe("interleaveImages", () => {
+  it("places each image after the given number of paragraphs (javelin passage)", () => {
+    // Real CAT 2021 Slot 3 javelin set: 7 paragraphs, tables at positions [4, 5]
+    const items = interleaveImages(P, ["first.png", "third.png"], [4, 5]);
+    const shape = items.map((i) => (i.kind === "text" ? i.value : `IMG:${i.url}`));
+    expect(shape).toEqual([
+      "para0",
+      "para1",
+      "para2",
+      "para3", // "...first round" caption
+      "IMG:first.png",
+      "para4", // "...third round" caption
+      "IMG:third.png",
+      "para5",
+      "para6",
+    ]);
+  });
+
+  it("emits an image at position 0 before the first paragraph", () => {
+    const items = interleaveImages("a\n\nb", ["x.png"], [0]);
+    expect(items.map((i) => (i.kind === "text" ? i.value : "IMG"))).toEqual(["IMG", "a", "b"]);
+  });
+
+  it("emits trailing images when position equals the paragraph count", () => {
+    const items = interleaveImages("a\n\nb", ["x.png"], [2]);
+    expect(items.map((i) => (i.kind === "text" ? i.value : "IMG"))).toEqual(["a", "b", "IMG"]);
+  });
+
+  it("interleaves several images at distinct positions (explanation)", () => {
+    const text = Array.from({ length: 16 }, (_, i) => `s${i}`).join("\n\n"); // 16 paragraphs
+    const items = interleaveImages(text, ["a", "b", "c", "d"], [2, 4, 7, 15]);
+    const imgAfter = items
+      .map((it, idx) => ({ it, idx }))
+      .filter((x) => x.it.kind === "image")
+      .map((x) => (items[x.idx - 1] as { value: string }).value);
+    // each image sits right after paragraph (position - 1)
+    expect(imgAfter).toEqual(["s1", "s3", "s6", "s14"]);
+  });
+
+  it("falls back to text-then-appended-images when positions are missing", () => {
+    const items = interleaveImages("a\n\nb", ["x.png", "y.png"]);
+    expect(items.map((i) => (i.kind === "text" ? i.value : `IMG:${i.url}`))).toEqual([
+      "a\n\nb",
+      "IMG:x.png",
+      "IMG:y.png",
+    ]);
+  });
+
+  it("falls back when positions length does not match image count", () => {
+    const items = interleaveImages("a\n\nb", ["x.png", "y.png"], [1]); // mismatch
+    expect(items.map((i) => (i.kind === "text" ? i.value : "IMG"))).toEqual(["a\n\nb", "IMG", "IMG"]);
+  });
+
+  it("handles image-only blocks (no paragraphs)", () => {
+    const items = interleaveImages("", ["x.png"], [0]);
+    expect(items).toEqual([{ kind: "image", url: "x.png", key: "img-0" }]);
+  });
+});

--- a/src/app/cat-prep/daily-dose/challenge/components/ComprehensionBlock.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/ComprehensionBlock.tsx
@@ -29,16 +29,17 @@ export default function ComprehensionBlock({
       >
         Passage
       </span>
-      {comprehension.imageUrl && (
-        /* imageUrl origin is user-supplied and unknown at build time — next/image requires
+      {comprehension.imageUrls.map((url) => (
+        /* image origin is scraper-supplied and unknown at build time — next/image requires
            pre-configured remotePatterns, so a plain img is used here */
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={comprehension.imageUrl}
+          key={url}
+          src={url}
           alt="Passage illustration"
           style={{ maxWidth: "100%", borderRadius: 6, marginBottom: 12 }}
         />
-      )}
+      ))}
       <p
         style={{
           fontSize: 14,

--- a/src/app/cat-prep/daily-dose/challenge/components/ComprehensionBlock.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/ComprehensionBlock.tsx
@@ -1,6 +1,7 @@
-// ComprehensionBlock — renders the reading passage and optional image for comprehension questions
+// ComprehensionBlock — renders the reading passage with its images placed inline
 import type { Comprehension } from "../../../models/dailyChallenge";
 import MathText from "./MathText";
+import InlineImageText from "./InlineImageText";
 
 export default function ComprehensionBlock({
   comprehension,
@@ -29,28 +30,28 @@ export default function ComprehensionBlock({
       >
         Passage
       </span>
-      {comprehension.imageUrls.map((url) => (
-        /* image origin is scraper-supplied and unknown at build time — next/image requires
-           pre-configured remotePatterns, so a plain img is used here */
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          key={url}
-          src={url}
-          alt="Passage illustration"
-          style={{ maxWidth: "100%", borderRadius: 6, marginBottom: 12 }}
-        />
-      ))}
-      <p
-        style={{
-          fontSize: 14,
-          color: "#475569",
-          lineHeight: 1.85,
-          margin: 0,
-          whiteSpace: "pre-line",
-        }}
-      >
-        <MathText text={comprehension.text} />
-      </p>
+      <InlineImageText
+        text={comprehension.text}
+        imageUrls={comprehension.imageUrls}
+        imagePositions={comprehension.imagePositions}
+        imgAlt="Passage illustration"
+        imgStyle={{ maxWidth: "100%", borderRadius: 6, marginBottom: 12 }}
+        renderParagraph={(segment, key) => (
+          <p
+            key={key}
+            style={{
+              fontSize: 14,
+              color: "#475569",
+              lineHeight: 1.85,
+              margin: 0,
+              marginBottom: 12,
+              whiteSpace: "pre-line",
+            }}
+          >
+            <MathText text={segment} />
+          </p>
+        )}
+      />
     </div>
   );
 }

--- a/src/app/cat-prep/daily-dose/challenge/components/InlineImageText.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/InlineImageText.tsx
@@ -1,0 +1,42 @@
+// InlineImageText — renders scraped text with its images placed inline at their
+// original positions, using the pure `interleaveImages` ordering (unit-tested).
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { interleaveImages } from "@/lib/interleaveImages";
+
+type Props = {
+  text: string;
+  imageUrls: string[];
+  imagePositions?: number[];
+  // Caller owns the paragraph markup (font, colour, MathText) so each surface keeps
+  // its own styling; InlineImageText only decides ordering.
+  renderParagraph: (segment: string, key: string) => ReactNode;
+  imgStyle?: CSSProperties;
+  imgAlt?: string;
+};
+
+export default function InlineImageText({
+  text,
+  imageUrls,
+  imagePositions,
+  renderParagraph,
+  imgStyle,
+  imgAlt = "Illustration",
+}: Props) {
+  const items = interleaveImages(text, imageUrls, imagePositions);
+  return (
+    <>
+      {items.map((item) =>
+        item.kind === "text" ? (
+          renderParagraph(item.value, item.key)
+        ) : (
+          // image origin is scraper-supplied and unknown at build time — next/image
+          // needs pre-configured remotePatterns, so a plain img is used here
+          // eslint-disable-next-line @next/next/no-img-element
+          <img key={item.key} src={item.url} alt={imgAlt} style={imgStyle} />
+        )
+      )}
+    </>
+  );
+}

--- a/src/app/cat-prep/daily-dose/challenge/components/MCQOptions.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/MCQOptions.tsx
@@ -54,14 +54,17 @@ export default function MCQOptions({ options, selected, onSelect }: Props) {
               {String.fromCharCode(65 + opt.index)}
             </span>
 
-            {opt.imageUrl ? (
-              /* imageUrl origin is user-supplied and unknown at build time */
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={opt.imageUrl}
-                alt={`Option ${String.fromCharCode(65 + opt.index)}`}
-                style={{ maxHeight: 60, borderRadius: 4 }}
-              />
+            {opt.imageUrls.length > 0 ? (
+              opt.imageUrls.map((url) => (
+                /* image origin is scraper-supplied and unknown at build time */
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={url}
+                  src={url}
+                  alt={`Option ${String.fromCharCode(65 + opt.index)}`}
+                  style={{ maxHeight: 60, borderRadius: 4 }}
+                />
+              ))
             ) : (
               <MathText text={opt.text ?? ""} />
             )}

--- a/src/app/cat-prep/daily-dose/challenge/components/QuestionRenderer.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/QuestionRenderer.tsx
@@ -57,16 +57,17 @@ export default function QuestionRenderer({
         </p>
       </div>
 
-      {/* Question image */}
-      {question.imageUrl && (
-        /* imageUrl origin is user-supplied and unknown at build time */
+      {/* Question images */}
+      {question.imageUrls.map((url) => (
+        /* image origin is scraper-supplied and unknown at build time */
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={question.imageUrl}
+          key={url}
+          src={url}
           alt="Question diagram"
           style={{ maxWidth: "100%", borderRadius: 8, marginBottom: 16 }}
         />
-      )}
+      ))}
 
       {/* Answer input */}
       {question.type === "mcq" && question.options ? (

--- a/src/app/cat-prep/daily-dose/challenge/components/QuestionRenderer.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/QuestionRenderer.tsx
@@ -3,6 +3,7 @@
 
 import type { Question } from "../../../models/dailyChallenge";
 import ComprehensionBlock from "./ComprehensionBlock";
+import InlineImageText from "./InlineImageText";
 import MathText from "./MathText";
 import MCQOptions from "./MCQOptions";
 import TITAInput from "./TITAInput";
@@ -49,25 +50,23 @@ export default function QuestionRenderer({
         >
           Q{questionNumber} · {question.type === "mcq" ? "MCQ" : "TITA"}
         </span>
-        <p
-          className="font-semibold text-trust-navy"
-          style={{ fontSize: 15, lineHeight: 1.75, margin: 0 }}
-        >
-          <MathText text={question.text} />
-        </p>
-      </div>
-
-      {/* Question images */}
-      {question.imageUrls.map((url) => (
-        /* image origin is scraper-supplied and unknown at build time */
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          key={url}
-          src={url}
-          alt="Question diagram"
-          style={{ maxWidth: "100%", borderRadius: 8, marginBottom: 16 }}
+        <InlineImageText
+          text={question.text}
+          imageUrls={question.imageUrls}
+          imagePositions={question.imagePositions}
+          imgAlt="Question diagram"
+          imgStyle={{ maxWidth: "100%", borderRadius: 8, marginTop: 12, marginBottom: 4 }}
+          renderParagraph={(segment, key) => (
+            <p
+              key={key}
+              className="font-semibold text-trust-navy"
+              style={{ fontSize: 15, lineHeight: 1.75, margin: 0, marginBottom: 8 }}
+            >
+              <MathText text={segment} />
+            </p>
+          )}
         />
-      ))}
+      </div>
 
       {/* Answer input */}
       {question.type === "mcq" && question.options ? (

--- a/src/app/cat-prep/daily-dose/challenge/components/QuestionReviewCard.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/QuestionReviewCard.tsx
@@ -2,6 +2,7 @@
 // question, image, options) but with answers locked and correctness highlighted
 import type { Question, QuestionResponse } from "../../../models/dailyChallenge";
 import ComprehensionBlock from "./ComprehensionBlock";
+import InlineImageText from "./InlineImageText";
 import MathText from "./MathText";
 import ReviewMCQOptions from "./ReviewMCQOptions";
 import ReviewTITAAnswer from "./ReviewTITAAnswer";
@@ -77,23 +78,22 @@ export default function QuestionReviewCard({ question, response, questionNumber 
 
       {question.comprehension && <ComprehensionBlock comprehension={question.comprehension} />}
 
-      <p
-        className="font-semibold text-trust-navy"
-        style={{ fontSize: 15, lineHeight: 1.75, margin: "0 0 14px" }}
-      >
-        <MathText text={question.text} />
-      </p>
-
-      {question.imageUrls.map((url) => (
-        /* image origin is scraper-supplied and unknown at build time */
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          key={url}
-          src={url}
-          alt="Question diagram"
-          style={{ maxWidth: "100%", borderRadius: 8, marginBottom: 16 }}
-        />
-      ))}
+      <InlineImageText
+        text={question.text}
+        imageUrls={question.imageUrls}
+        imagePositions={question.imagePositions}
+        imgAlt="Question diagram"
+        imgStyle={{ maxWidth: "100%", borderRadius: 8, marginTop: 10, marginBottom: 14 }}
+        renderParagraph={(segment, key) => (
+          <p
+            key={key}
+            className="font-semibold text-trust-navy"
+            style={{ fontSize: 15, lineHeight: 1.75, margin: "0 0 10px" }}
+          >
+            <MathText text={segment} />
+          </p>
+        )}
+      />
 
       {question.type === "mcq" && question.options ? (
         <ReviewMCQOptions options={question.options} selectedIndex={given} correctIndex={correctAnswer} />
@@ -101,7 +101,7 @@ export default function QuestionReviewCard({ question, response, questionNumber 
         <ReviewTITAAnswer given={given} correctAnswer={correctAnswer} isCorrect={isCorrect} />
       )}
 
-      {question.explanation?.text && (
+      {question.explanation && (question.explanation.text || question.explanation.imageUrls.length > 0) && (
         <div
           style={{
             marginTop: 16,
@@ -123,14 +123,18 @@ export default function QuestionReviewCard({ question, response, questionNumber 
           >
             Explanation
           </span>
-          <p style={{ fontSize: 13.5, color: "#334155", lineHeight: 1.75, margin: 0, whiteSpace: "pre-line" }}>
-            <MathText text={question.explanation.text} />
-          </p>
-          {question.explanation.imageUrls.map((url) => (
-            /* imageUrl origin is scraper-supplied and unknown at build time */
-            // eslint-disable-next-line @next/next/no-img-element
-            <img key={url} src={url} alt="Explanation diagram" style={{ maxWidth: "100%", borderRadius: 8, marginTop: 10 }} />
-          ))}
+          <InlineImageText
+            text={question.explanation.text ?? ""}
+            imageUrls={question.explanation.imageUrls}
+            imagePositions={question.explanation.imagePositions}
+            imgAlt="Explanation diagram"
+            imgStyle={{ maxWidth: "100%", borderRadius: 8, marginTop: 10, marginBottom: 6 }}
+            renderParagraph={(segment, key) => (
+              <p key={key} style={{ fontSize: 13.5, color: "#334155", lineHeight: 1.75, margin: "0 0 8px", whiteSpace: "pre-line" }}>
+                <MathText text={segment} />
+              </p>
+            )}
+          />
         </div>
       )}
     </div>

--- a/src/app/cat-prep/daily-dose/challenge/components/QuestionReviewCard.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/QuestionReviewCard.tsx
@@ -84,15 +84,16 @@ export default function QuestionReviewCard({ question, response, questionNumber 
         <MathText text={question.text} />
       </p>
 
-      {question.imageUrl && (
-        /* imageUrl origin is user-supplied and unknown at build time */
+      {question.imageUrls.map((url) => (
+        /* image origin is scraper-supplied and unknown at build time */
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={question.imageUrl}
+          key={url}
+          src={url}
           alt="Question diagram"
           style={{ maxWidth: "100%", borderRadius: 8, marginBottom: 16 }}
         />
-      )}
+      ))}
 
       {question.type === "mcq" && question.options ? (
         <ReviewMCQOptions options={question.options} selectedIndex={given} correctIndex={correctAnswer} />

--- a/src/app/cat-prep/daily-dose/challenge/components/ReviewMCQOptions.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/components/ReviewMCQOptions.tsx
@@ -62,14 +62,19 @@ export default function ReviewMCQOptions({ options, selectedIndex, correctIndex 
               {String.fromCharCode(65 + opt.index)}
             </span>
 
-            {opt.imageUrl ? (
-              /* imageUrl origin is user-supplied and unknown at build time */
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={opt.imageUrl}
-                alt={`Option ${String.fromCharCode(65 + opt.index)}`}
-                style={{ maxHeight: 60, borderRadius: 4 }}
-              />
+            {opt.imageUrls.length > 0 ? (
+              <span style={{ flex: 1, display: "flex", flexDirection: "column", gap: 6 }}>
+                {opt.imageUrls.map((url) => (
+                  /* image origin is scraper-supplied and unknown at build time */
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    key={url}
+                    src={url}
+                    alt={`Option ${String.fromCharCode(65 + opt.index)}`}
+                    style={{ maxHeight: 60, borderRadius: 4 }}
+                  />
+                ))}
+              </span>
             ) : (
               <span style={{ flex: 1 }}>
                 <MathText text={opt.text ?? ""} />

--- a/src/app/cat-prep/models/dailyChallenge.ts
+++ b/src/app/cat-prep/models/dailyChallenge.ts
@@ -17,11 +17,15 @@ export type QuestionOption = {
 export type Comprehension = {
   text: string;
   imageUrls: string[];
+  // Inline position per image: paragraphs preceding image i. Optional — absent on
+  // docs not yet backfilled, in which case images render appended at the end.
+  imagePositions?: number[];
 };
 
 export type Explanation = {
   text: string | null;
   imageUrls: string[];
+  imagePositions?: number[];
 };
 
 export type Question = {
@@ -30,6 +34,7 @@ export type Question = {
   type: QuestionType;
   text: string;
   imageUrls: string[];
+  imagePositions?: number[];
   options: QuestionOption[] | null;
   timeLimitSeconds: number | null;
   comprehension: Comprehension | null;

--- a/src/app/cat-prep/models/dailyChallenge.ts
+++ b/src/app/cat-prep/models/dailyChallenge.ts
@@ -11,12 +11,12 @@ export type VisitStatus =
 export type QuestionOption = {
   index: number;
   text: string | null;
-  imageUrl: string | null;
+  imageUrls: string[];
 };
 
 export type Comprehension = {
   text: string;
-  imageUrl: string | null;
+  imageUrls: string[];
 };
 
 export type Explanation = {
@@ -29,7 +29,7 @@ export type Question = {
   order: number;
   type: QuestionType;
   text: string;
-  imageUrl: string | null;
+  imageUrls: string[];
   options: QuestionOption[] | null;
   timeLimitSeconds: number | null;
   comprehension: Comprehension | null;

--- a/src/app/cat-prep/models/pyq.ts
+++ b/src/app/cat-prep/models/pyq.ts
@@ -13,6 +13,7 @@ export type PyqComprehension = {
   id: string;
   text: string | null;
   imageUrls: string[];
+  imagePositions?: number[];
 };
 
 export type PyqQuestion = {
@@ -22,6 +23,7 @@ export type PyqQuestion = {
   type: PyqQuestionType;
   text: string | null;
   imageUrls: string[];
+  imagePositions?: number[];
   options: PyqOption[] | null;
   comprehension: PyqComprehension | null;
 };
@@ -46,7 +48,7 @@ export type PyqSolution = {
   type: PyqQuestionType;
   correctOptionIndex: number | null;
   correctAnswer: string | null;
-  explanation: { text: string | null; imageUrls: string[] };
+  explanation: { text: string | null; imageUrls: string[]; imagePositions?: number[] };
 };
 
 export type PyqPaperSummary = {

--- a/src/app/cat-prep/pyq/[paperSlug]/PyqPaperPlayer.tsx
+++ b/src/app/cat-prep/pyq/[paperSlug]/PyqPaperPlayer.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { onAuthStateChanged, signInWithPopup, type User } from "firebase/auth";
 import { auth, googleProvider } from "@/lib/firebase";
 import type { PyqPaper, PyqQuestion, PyqSection, PyqSolution } from "@/app/cat-prep/models/pyq";
+import { interleaveImages } from "@/lib/interleaveImages";
 import { usePracticeProgress } from "@/app/cat-prep/lib/usePracticeProgress";
 import { PracticeOptionButton, type OptionState } from "@/app/cat-prep/components/practice/PracticeOptionButton";
 import { PracticePalette, type PillState } from "@/app/cat-prep/components/practice/PracticePalette";
@@ -20,6 +21,7 @@ type Group = {
   comprehensionId: string | null;
   comprehensionText: string | null;
   comprehensionImages: string[];
+  comprehensionImagePositions?: number[];
   questions: PyqQuestion[];
 };
 
@@ -36,6 +38,7 @@ function buildGroupsByQuestionNumber(questions: PyqQuestion[]): Map<number, Grou
         comprehensionId: q.comprehension?.id ?? null,
         comprehensionText: q.comprehension?.text ?? null,
         comprehensionImages: q.comprehension?.imageUrls ?? [],
+        comprehensionImagePositions: q.comprehension?.imagePositions,
         questions: [q],
       };
     }
@@ -93,6 +96,42 @@ function MathContent({ text, containerRef }: { text: string; containerRef: React
     }
   }, [html, containerRef]);
   return <span dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+// Renders scraped text with its images interleaved at their original positions
+// (see interleaveImages); falls back to text-then-appended-images when a block has
+// no positions. Mirrors InlineImageText but uses this player's MathContent renderer.
+function InlineContent({
+  text,
+  imageUrls,
+  imagePositions,
+  containerRef,
+  textStyle,
+  imgStyle,
+}: {
+  text: string;
+  imageUrls: string[];
+  imagePositions?: number[];
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  textStyle?: React.CSSProperties;
+  imgStyle?: React.CSSProperties;
+}) {
+  const items = interleaveImages(text ?? "", imageUrls ?? [], imagePositions);
+  return (
+    <>
+      {items.map((item) =>
+        item.kind === "text" ? (
+          <p key={item.key} style={textStyle}>
+            <MathContent text={item.value} containerRef={containerRef} />
+          </p>
+        ) : (
+          // image origin is scraper-supplied and unknown at build time
+          // eslint-disable-next-line @next/next/no-img-element
+          <img key={item.key} src={item.url} alt="" style={imgStyle} />
+        )
+      )}
+    </>
+  );
 }
 
 export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
@@ -181,10 +220,14 @@ export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
 
   const passageContent = group?.comprehensionText ? (
     <div>
-      <p style={{ fontSize: 14, color: "#334155", lineHeight: 1.8, whiteSpace: "pre-line", margin: 0 }}>
-        <MathContent text={group.comprehensionText} containerRef={containerRef} />
-      </p>
-      <ImageStack urls={group.comprehensionImages} />
+      <InlineContent
+        text={group.comprehensionText}
+        imageUrls={group.comprehensionImages}
+        imagePositions={group.comprehensionImagePositions}
+        containerRef={containerRef}
+        textStyle={{ fontSize: 14, color: "#334155", lineHeight: 1.8, whiteSpace: "pre-line", margin: "0 0 10px" }}
+        imgStyle={{ maxWidth: "100%", borderRadius: 8, marginBottom: 10 }}
+      />
     </div>
   ) : null;
 
@@ -198,10 +241,14 @@ export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
         </span>
       </div>
 
-      <div style={{ fontSize: 15, color: "#1E3A5F", fontWeight: 500, lineHeight: 1.7, whiteSpace: "pre-line" }}>
-        <MathContent text={question.text ?? ""} containerRef={containerRef} />
-      </div>
-      <ImageStack urls={question.imageUrls} />
+      <InlineContent
+        text={question.text ?? ""}
+        imageUrls={question.imageUrls}
+        imagePositions={question.imagePositions}
+        containerRef={containerRef}
+        textStyle={{ fontSize: 15, color: "#1E3A5F", fontWeight: 500, lineHeight: 1.7, whiteSpace: "pre-line", margin: "0 0 8px" }}
+        imgStyle={{ maxWidth: "100%", borderRadius: 8, marginBottom: 8 }}
+      />
 
       <div style={{ marginTop: 16 }}>
         {question.type === "mcq" && question.options ? (
@@ -275,14 +322,18 @@ export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
           <div className="font-bold text-trust-navy" style={{ fontSize: 13, marginBottom: 8 }}>
             Explanation
           </div>
-          {solution.explanation.text ? (
-            <p style={{ fontSize: 14, color: "#334155", lineHeight: 1.7, whiteSpace: "pre-line", margin: 0 }}>
-              <MathContent text={solution.explanation.text} containerRef={containerRef} />
-            </p>
+          {solution.explanation.text || solution.explanation.imageUrls.length > 0 ? (
+            <InlineContent
+              text={solution.explanation.text ?? ""}
+              imageUrls={solution.explanation.imageUrls}
+              imagePositions={solution.explanation.imagePositions}
+              containerRef={containerRef}
+              textStyle={{ fontSize: 14, color: "#334155", lineHeight: 1.7, whiteSpace: "pre-line", margin: "0 0 8px" }}
+              imgStyle={{ maxWidth: "100%", borderRadius: 8, marginBottom: 8 }}
+            />
           ) : (
             <p style={{ fontSize: 14, color: "#94A3B8", margin: 0 }}>No explanation available.</p>
           )}
-          <ImageStack urls={solution.explanation.imageUrls} />
         </div>
       )}
 

--- a/src/lib/dailyQuizQueries.ts
+++ b/src/lib/dailyQuizQueries.ts
@@ -24,6 +24,7 @@ type QuestionDoc = {
   type: "mcq" | "tita";
   text: string;
   imageUrls: string[];
+  imagePositions?: number[];
   options?: { index: number; text: string; imageUrls: string[] }[];
   correctOptionIndex?: number;
   correctAnswer?: string;
@@ -34,6 +35,7 @@ type ComprehensionDoc = {
   _id: ObjectId;
   text: string;
   imageUrls: string[];
+  imagePositions?: number[];
 };
 
 // Stored attempt — includes full result object for easy retrieval
@@ -94,13 +96,13 @@ export async function fetchDailyTest(date: string): Promise<DailyTest | null> {
       (questionOrder.get(b._id.toString()) ?? 0)
   );
 
-  let comprehension: { text: string; imageUrls: string[] } | null = null;
+  let comprehension: { text: string; imageUrls: string[]; imagePositions?: number[] } | null = null;
   if (quiz.isComprehension && quiz.comprehensionId) {
     const comp = await db
       .collection<ComprehensionDoc>("cracku_pyq_comprehensions")
       .findOne({ _id: quiz.comprehensionId });
     if (comp) {
-      comprehension = { text: comp.text, imageUrls: comp.imageUrls };
+      comprehension = { text: comp.text, imageUrls: comp.imageUrls, imagePositions: comp.imagePositions };
     }
   }
 
@@ -112,6 +114,7 @@ export async function fetchDailyTest(date: string): Promise<DailyTest | null> {
     type: q.type,
     text: q.text,
     imageUrls: q.imageUrls,
+    imagePositions: q.imagePositions,
     options: q.options
       ? q.options.map((o) => ({
           index: o.index,

--- a/src/lib/dailyQuizQueries.ts
+++ b/src/lib/dailyQuizQueries.ts
@@ -94,13 +94,13 @@ export async function fetchDailyTest(date: string): Promise<DailyTest | null> {
       (questionOrder.get(b._id.toString()) ?? 0)
   );
 
-  let comprehension: { text: string; imageUrl: string | null } | null = null;
+  let comprehension: { text: string; imageUrls: string[] } | null = null;
   if (quiz.isComprehension && quiz.comprehensionId) {
     const comp = await db
       .collection<ComprehensionDoc>("cracku_pyq_comprehensions")
       .findOne({ _id: quiz.comprehensionId });
     if (comp) {
-      comprehension = { text: comp.text, imageUrl: comp.imageUrls[0] ?? null };
+      comprehension = { text: comp.text, imageUrls: comp.imageUrls };
     }
   }
 
@@ -111,12 +111,12 @@ export async function fetchDailyTest(date: string): Promise<DailyTest | null> {
     order: i + 1,
     type: q.type,
     text: q.text,
-    imageUrl: q.imageUrls[0] ?? null,
+    imageUrls: q.imageUrls,
     options: q.options
       ? q.options.map((o) => ({
           index: o.index,
           text: o.text ?? null,
-          imageUrl: o.imageUrls[0] ?? null,
+          imageUrls: o.imageUrls,
         }))
       : null,
     timeLimitSeconds: questionTimeLimit,

--- a/src/lib/interleaveImages.ts
+++ b/src/lib/interleaveImages.ts
@@ -1,0 +1,48 @@
+// interleaveImages — pure ordering logic shared by InlineImageText.
+//
+// `imagePositions[i]` is the number of paragraphs (the "\n\n"-separated segments of
+// `text`) that precede image `i`, so an image with position k renders after the first
+// k paragraphs. Returns text/image items in final render order.
+//
+// When positions are absent or don't line up with the image list (a doc not yet
+// backfilled), it falls back to the legacy layout: the whole text, then every image
+// appended at the end.
+
+export type InlineItem =
+  | { kind: "text"; value: string; key: string }
+  | { kind: "image"; url: string; key: string };
+
+export function interleaveImages(
+  text: string,
+  imageUrls: string[],
+  imagePositions?: number[]
+): InlineItem[] {
+  const urls = imageUrls ?? [];
+  const positions = imagePositions ?? [];
+  const aligned = urls.length > 0 && positions.length === urls.length;
+  const items: InlineItem[] = [];
+
+  if (!aligned) {
+    if (text) items.push({ kind: "text", value: text, key: "text" });
+    urls.forEach((url, i) => items.push({ kind: "image", url, key: `img-${i}` }));
+    return items;
+  }
+
+  const paragraphs = text ? text.split("\n\n") : [];
+  const emitImagesAt = (paraCount: number) =>
+    urls.forEach((url, i) => {
+      if (positions[i] === paraCount) items.push({ kind: "image", url, key: `img-${i}` });
+    });
+
+  for (let j = 0; j < paragraphs.length; j++) {
+    emitImagesAt(j);
+    const segment = paragraphs[j];
+    if (segment && segment.trim()) items.push({ kind: "text", value: segment, key: `para-${j}` });
+  }
+  // Trailing images (position at or past the last paragraph).
+  urls.forEach((url, i) => {
+    if (positions[i] >= paragraphs.length) items.push({ kind: "image", url, key: `img-${i}` });
+  });
+
+  return items;
+}

--- a/src/lib/pyqQueries.ts
+++ b/src/lib/pyqQueries.ts
@@ -42,10 +42,11 @@ type PyqQuestionDoc = {
   type: PyqQuestionType;
   text: string | null;
   imageUrls: string[];
+  imagePositions?: number[];
   options: PyqOption[] | null;
   correctOptionIndex?: number | null;
   correctAnswer?: string | null;
-  explanation?: { text: string | null; imageUrls: string[] };
+  explanation?: { text: string | null; imageUrls: string[]; imagePositions?: number[] };
   comprehensionId: ObjectId | null;
 };
 
@@ -53,6 +54,7 @@ type PyqComprehensionDoc = {
   _id: ObjectId;
   text: string | null;
   imageUrls: string[];
+  imagePositions?: number[];
 };
 
 // ---- Helpers ----
@@ -74,11 +76,12 @@ function toPyqQuestion(
     type: doc.type,
     text: doc.text,
     imageUrls: doc.imageUrls,
+    imagePositions: doc.imagePositions,
     options: doc.options
       ? doc.options.map(({ index, text, imageUrls }) => ({ index, text, imageUrls }))
       : null,
     comprehension: comp
-      ? { id: comp._id.toString(), text: comp.text, imageUrls: comp.imageUrls }
+      ? { id: comp._id.toString(), text: comp.text, imageUrls: comp.imageUrls, imagePositions: comp.imagePositions }
       : null,
   };
 }
@@ -219,13 +222,14 @@ export async function fetchPyqMockTest(paperSlug: string): Promise<DailyTest | n
       type: q.type,
       text: q.text ?? "",
       imageUrls: q.imageUrls,
+      imagePositions: q.imagePositions,
       options: q.options
         ? q.options.map((o) => ({ index: o.index, text: o.text, imageUrls: o.imageUrls }))
         : null,
       // CAT has no per-question time limit — only a per-section budget
       timeLimitSeconds: null,
       comprehension: q.comprehension
-        ? { text: q.comprehension.text ?? "", imageUrls: q.comprehension.imageUrls }
+        ? { text: q.comprehension.text ?? "", imageUrls: q.comprehension.imageUrls, imagePositions: q.comprehension.imagePositions }
         : null,
     })),
   }));
@@ -262,12 +266,15 @@ export async function fetchPyqMockReviewTest(paperSlug: string): Promise<DailyTe
       type: doc.type,
       text: doc.text ?? "",
       imageUrls: doc.imageUrls,
+      imagePositions: doc.imagePositions,
       options: doc.options
         ? doc.options.map((o) => ({ index: o.index, text: o.text, imageUrls: o.imageUrls }))
         : null,
       timeLimitSeconds: null,
-      comprehension: comp ? { text: comp.text ?? "", imageUrls: comp.imageUrls } : null,
-      explanation: doc.explanation ? { text: doc.explanation.text, imageUrls: doc.explanation.imageUrls } : null,
+      comprehension: comp ? { text: comp.text ?? "", imageUrls: comp.imageUrls, imagePositions: comp.imagePositions } : null,
+      explanation: doc.explanation
+        ? { text: doc.explanation.text, imageUrls: doc.explanation.imageUrls, imagePositions: doc.explanation.imagePositions }
+        : null,
     });
   }
 

--- a/src/lib/pyqQueries.ts
+++ b/src/lib/pyqQueries.ts
@@ -218,14 +218,14 @@ export async function fetchPyqMockTest(paperSlug: string): Promise<DailyTest | n
       order: i + 1,
       type: q.type,
       text: q.text ?? "",
-      imageUrl: q.imageUrls[0] ?? null,
+      imageUrls: q.imageUrls,
       options: q.options
-        ? q.options.map((o) => ({ index: o.index, text: o.text, imageUrl: o.imageUrls[0] ?? null }))
+        ? q.options.map((o) => ({ index: o.index, text: o.text, imageUrls: o.imageUrls }))
         : null,
       // CAT has no per-question time limit — only a per-section budget
       timeLimitSeconds: null,
       comprehension: q.comprehension
-        ? { text: q.comprehension.text ?? "", imageUrl: q.comprehension.imageUrls[0] ?? null }
+        ? { text: q.comprehension.text ?? "", imageUrls: q.comprehension.imageUrls }
         : null,
     })),
   }));
@@ -261,12 +261,12 @@ export async function fetchPyqMockReviewTest(paperSlug: string): Promise<DailyTe
       order: doc.questionNumber,
       type: doc.type,
       text: doc.text ?? "",
-      imageUrl: doc.imageUrls[0] ?? null,
+      imageUrls: doc.imageUrls,
       options: doc.options
-        ? doc.options.map((o) => ({ index: o.index, text: o.text, imageUrl: o.imageUrls[0] ?? null }))
+        ? doc.options.map((o) => ({ index: o.index, text: o.text, imageUrls: o.imageUrls }))
         : null,
       timeLimitSeconds: null,
-      comprehension: comp ? { text: comp.text ?? "", imageUrl: comp.imageUrls[0] ?? null } : null,
+      comprehension: comp ? { text: comp.text ?? "", imageUrls: comp.imageUrls } : null,
       explanation: doc.explanation ? { text: doc.explanation.text, imageUrls: doc.explanation.imageUrls } : null,
     });
   }


### PR DESCRIPTION
Fixes two image bugs a user hit taking CAT 2021 Slot 3 as a mock: a passage image was **missing**, and the images that did show were in the **wrong place**. Now fixed across every cracku-PYQ surface.

## Bug #1 — missing images

The mock, mock-review, and daily-quiz loaders collapsed each `imageUrls` array to `imageUrls[0]`, silently dropping every image after the first from **passages, question text, and options**. Multi-table DILR sets lost their extra tables — e.g. the CAT 2021 Slot 3 javelin set kept only the *first-round* table and dropped the *third-round* one. Audit across all 39 papers: **36 images** dropped this way.

**Fix:** `Comprehension` / `Question` / `QuestionOption` go from singular `imageUrl` → **`imageUrls: string[]`** (matching the existing `Explanation.imageUrls`); loaders pass full arrays; components render every image.

## Bug #2 — wrong position

Even with all images present, they rendered detached from the text (passage images at the top, explanation images at the bottom) because the stored data carried no inline position. Captions like *"…first round"* / *"…third round"* pointed at nothing.

**Fix:** add optional **`imagePositions: number[]`** (paragraphs preceding each image, index-aligned with `imageUrls`) to `Comprehension` / `Question` / `Explanation` and the flat PYQ model; thread it through all loaders; interleave text + images via a new pure `interleaveImages` helper (unit-tested) rendered by `InlineImageText` (daily-challenge surfaces) and an equivalent `InlineContent` in the browse player. Falls back to append-at-end when a block has no positions.

**Data:** backfilled in Mongo from the recovered image-context manifest (`PYQ-scraper/apply_image_positions.py`, strict length-verified) — **157 passages, 48 question texts, 741 explanations**.

## Surfaces covered

All cracku-PYQ surfaces now render images inline:
- Mock (taking) + mock review
- Daily challenge + daily-challenge review (same collections + components)
- Browse player (`PyqPaperPlayer`) — passage / question / explanation interleaved; options keep `ImageStack`

Out of scope (different pipeline / repo):
- **Practice** (DILR/RC/Quant) uses the separate `percentyl_*` collections with a single inline `question_svg`/`solution_svg` per item — no `imageUrls` arrays, so this bug doesn't exist there; images already render inline.
- **Flask admin** template (PYQ-scraper repo) — internal preview; still appends. Ignores the new field, so no regression.

## Verification

- `tsc --noEmit` clean · `eslint` clean · `vitest` **19/19** (7 new `interleaveImages` tests incl. the real javelin case)
- Live (local dev server) end-to-end:
  - mock API → javelin passage `imageUrls:[first,third]`, `imagePositions:[4,5]`
  - daily-quiz API → passage `imagePositions:[2]`
  - solution API → Q35 explanation `imagePositions:[2,4,7,15]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)