### PR TITLE
Show explanations in daily-challenge review + revisited browse questions

### DIFF
--- a/src/app/cat-prep/daily-dose/challenge/review/page.tsx
+++ b/src/app/cat-prep/daily-dose/challenge/review/page.tsx
@@ -14,7 +14,8 @@ export default async function DailyChallengeReviewPage({ searchParams }: Props) 
   const { date: requestedDate } = await searchParams;
   const date = requestedDate ?? getTodayDate();
 
-  const test = await fetchDailyTest(date);
+  // Review is post-attempt, so include explanations (mirrors the mock review).
+  const test = await fetchDailyTest(date, { includeExplanation: true });
   if (!test) notFound();
 
   return <DailyChallengeReviewPageClient test={test} date={date} />;

--- a/src/app/cat-prep/pyq/[paperSlug]/PyqPaperPlayer.tsx
+++ b/src/app/cat-prep/pyq/[paperSlug]/PyqPaperPlayer.tsx
@@ -154,6 +154,9 @@ export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
   const { answers, correctAnswers, setAnswer, setCorrectAnswer } = usePracticeProgress(paper.paperSlug);
   const [sessionSolutions, setSessionSolutions] = useState<Record<number, PyqSolution>>({});
   const [loading, setLoading] = useState(false);
+  // Questions whose solution we've already kicked off a fetch for, so the
+  // auto-load effect below never re-fetches or loops.
+  const autoLoadedRef = useRef<Set<number>>(new Set());
 
   const currentIndex = section.questions.findIndex((q) => q.questionNumber === currentQNum);
   const question = section.questions[currentIndex];
@@ -163,6 +166,31 @@ export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
   const correctLetter = question ? correctAnswers[question.questionNumber] : undefined;
   const isChecked = !!correctLetter;
   const solution = question ? sessionSolutions[question.questionNumber] : undefined;
+
+  // A question stays "checked" across reloads/navigation because correctAnswers is
+  // persisted — but its solution lives only in component state and is lost. Without
+  // this, a revisited question shows the answer key with no explanation and no
+  // "Check Answer" button to re-fetch it. Re-load the solution when that happens.
+  useEffect(() => {
+    if (!question || !isChecked || sessionSolutions[question.questionNumber]) return;
+    const qNum = question.questionNumber;
+    if (autoLoadedRef.current.has(qNum)) return;
+    autoLoadedRef.current.add(qNum);
+    const qId = question.id;
+    (async () => {
+      try {
+        const res = await fetch(`/api/pyq/${paper.paperSlug}/questions/${qId}/solution`);
+        if (!res.ok) {
+          autoLoadedRef.current.delete(qNum);
+          return;
+        }
+        const data = (await res.json()) as PyqSolution;
+        setSessionSolutions((prev) => ({ ...prev, [qNum]: data }));
+      } catch {
+        autoLoadedRef.current.delete(qNum);
+      }
+    })();
+  }, [question, isChecked, sessionSolutions, paper.paperSlug]);
 
   function switchSection(name: PyqSection) {
     setActiveSection(name);
@@ -177,6 +205,8 @@ export default function PyqPaperPlayer({ paper }: { paper: PyqPaper }) {
 
   async function checkAnswer() {
     if (!question || !given) return;
+    // Mark as loaded so the auto-load effect doesn't also fire for this question.
+    autoLoadedRef.current.add(question.questionNumber);
     setLoading(true);
     try {
       const res = await fetch(`/api/pyq/${paper.paperSlug}/questions/${question.id}/solution`);

--- a/src/lib/dailyQuizQueries.ts
+++ b/src/lib/dailyQuizQueries.ts
@@ -28,6 +28,7 @@ type QuestionDoc = {
   options?: { index: number; text: string; imageUrls: string[] }[];
   correctOptionIndex?: number;
   correctAnswer?: string;
+  explanation?: { text: string | null; imageUrls: string[]; imagePositions?: number[] };
   comprehension_id?: ObjectId;
 };
 
@@ -70,8 +71,15 @@ function getQuestionTimeLimitSeconds(): number | null {
 /**
  * Fetch today's quiz from MongoDB and return a DailyTest (without correct answers).
  * Returns null when no quiz is scheduled for the given date.
+ *
+ * Pass `{ includeExplanation: true }` on the post-attempt review path so each
+ * question carries its explanation (text + images). It's omitted by default so the
+ * live-test fetch never ships explanations to an in-progress attempt.
  */
-export async function fetchDailyTest(date: string): Promise<DailyTest | null> {
+export async function fetchDailyTest(
+  date: string,
+  opts: { includeExplanation?: boolean } = {}
+): Promise<DailyTest | null> {
   const db = await getDb();
 
   const quiz = await db.collection<QuizDoc>("daily_quizzes").findOne({ date });
@@ -124,6 +132,14 @@ export async function fetchDailyTest(date: string): Promise<DailyTest | null> {
       : null,
     timeLimitSeconds: questionTimeLimit,
     comprehension,
+    explanation:
+      opts.includeExplanation && q.explanation
+        ? {
+            text: q.explanation.text,
+            imageUrls: q.explanation.imageUrls,
+            imagePositions: q.explanation.imagePositions,
+          }
+        : undefined,
   }));
 
   return {


### PR DESCRIPTION
Two fixes so a learner always sees the **explanation**, not just the answer key.

## Bug 1 — daily-challenge review has no explanation

After completing a daily challenge, the review showed only the correct answer — unlike the mock review, which shows the full explanation. Cause: the review page fetched the test via `fetchDailyTest`, the answer-stripped *live-test* fetch that never maps `explanation`. (The mock review uses a dedicated `fetchPyqMockReviewTest` that includes it.)

**Fix:** add an opt-in `{ includeExplanation: true }` to `fetchDailyTest` and set it on the review page only — the live-test path stays explanation-free so an in-progress attempt never receives them. `QuestionReviewCard` already renders explanation text + images.

## Bug 2 — browse player hides the explanation on revisit

In the PYQ browse player, checking an answer fetches the solution and shows the explanation. But `isChecked` is derived from **persisted** progress (`correctAnswers`), while the solution lives only in **component state** (`sessionSolutions`). So on reload or when navigating back to a checked question, you'd see attempted/correct/correct-option but **no explanation**, and the "Check Answer" button is gone (already checked) — no way to re-fetch.

**Fix:** a ref-guarded effect re-loads the solution for any already-checked question whose solution isn't in state, so the explanation reappears. `checkAnswer` marks the question loaded to avoid a double-fetch.

## Verification

- `tsc --noEmit` clean · `eslint` clean · `vitest` 19/19
- Confirmed all 45 daily-quiz-referenced questions have `explanation.text` in Mongo, so the review now renders them
- Both pages compile 200 on the local dev server (daily review + browse player)

## Note

Branched from `staging` (which already carries the image-inline work). This is independent of PR #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)