### PR TITLE
Serve the 150 orphaned VARC questions, and server-render the practice player

### DIFF
--- a/planning/G008-varc-verbal-practice.md
+++ b/planning/G008-varc-verbal-practice.md
@@ -1,0 +1,68 @@
+# G008 — VARC Verbal Practice Pages
+
+## Goal
+
+150 CAT practice questions sit in MongoDB with no page serving them. `percentyl_practice_questions` holds three VARC chapters — Para Jumbles, Para Summary and Odd One Out, 50 questions each — and the only practice question route is `/cat-prep/practice/quant/[topic]/[chapter]`, which filters on `section: "Quant"`.
+
+Worse than invisible: `PracticeTopicRow.tsx:36` already builds `/cat-prep/practice/varc/${topicSlug}/${chapterSlug}` for these chapters, so all three chips on the roadmap lead a real user to a 404. Same class of defect as the three quant chapters fixed in G007, found the same way.
+
+This builds the route, fixes the links, and lists the pages. Unlike the daily essay archive, this content genuinely deserves indexing: it is CAT practice material on CAT-intent queries, and "para jumbles for CAT" is something aspirants actually search.
+
+## URL shape
+
+`/cat-prep/practice/varc/[chapter]` — `para-jumbles`, `para-summary`, `odd-one-out`.
+
+One segment, not the quant route's two. The constants nest these under a topic named "Verbal Ability & Reading Comprehension" (slug `varc`), which would have produced `/practice/varc/varc/para-jumbles`. The topic carries no meaning here — it holds every VARC chapter — so it is dropped from the URL.
+
+`reading-comprehensions` also matches this segment, since the existing RC route lives one level deeper at `varc/reading-comprehensions/[rcNumber]`. That case redirects to `/1` rather than 404ing.
+
+## The data, and what it forces
+
+| Chapter | Questions | Type | Answer field |
+|---|---|---|---|
+| Para Summary | 50 | `mcq` | `correct_answer` — A–D |
+| Odd One Out | 50 | `mcq` | `correct_answer` — A–D on 40, **null on 10** |
+| Para Jumbles | 50 | `jumble` | `correct_text` — a 4-digit sequence, e.g. `2413`; `correct_answer` is null on all 50 |
+
+Two consequences for the player, which today only understands A–D:
+
+**Jumble questions are not multiple choice.** The four options hold the sentences; the answer is the order they go in. They render as a numbered list with a sequence input, which is how CAT actually asks them.
+
+**Ten Odd One Out questions have no answer key at all** — both `correct_answer` and `correct_text` are null. Checking one must say so and move on, not hang on a disabled button. A sentinel marks the question checked without matching any real answer, mirroring `NO_ANSWER_SENTINEL` in the PYQ reader.
+
+## Files Affected
+
+- `src/app/cat-prep/practice/varc/[chapter]/page.tsx` — **new**. Metadata, JSON-LD, `generateStaticParams`, and the RC redirect.
+- `src/app/cat-prep/practice/quant/[topic]/[chapter]/QuestionPlayer.tsx` — teach it the `jumble` type and the missing-answer case. Extended rather than copied: the palette, navigation, progress, MathJax and solution fetching are all identical, and only the answer widget differs.
+- `src/app/cat-prep/components/PracticeTopicRow.tsx` — point the three chips at the route that now exists.
+- `src/app/sitemap.ts` — three entries.
+
+## Acceptance Criteria
+
+- [ ] `/cat-prep/practice/varc/{para-jumbles,para-summary,odd-one-out}` each return 200 and render 50 questions.
+- [ ] Para Summary and Odd One Out behave exactly like a quant chapter: pick A–D, check, see the explanation.
+- [ ] Para Jumbles shows four numbered sentences and accepts a sequence; `2413` marks correct, anything else incorrect with the right sequence shown.
+- [ ] The 10 answer-less Odd One Out questions report that the answer is unavailable rather than leaving the button dead.
+- [ ] Quant chapter pages are unchanged — same behaviour, same markup.
+- [ ] The three roadmap chips navigate instead of 404ing.
+- [ ] `/cat-prep/practice/varc/reading-comprehensions` redirects to `/1`.
+- [ ] Sitemap gains exactly 3 URLs, all returning 200.
+- [ ] Titles contain "CAT" and stay under 60 characters.
+- [ ] `tsc`, `eslint`, `vitest`, `next build` clean.
+
+## Test Plan
+
+- Answer an MCQ on Para Summary; confirm correct/incorrect and explanation.
+- Answer Para Jumbles q1 with `2413`, then with `1234`; confirm both verdicts read correctly.
+- Open Odd One Out q2 (no key) and check it; confirm the message and that navigation still works.
+- Reload mid-chapter; confirm answers persist, logged out.
+- Walk the whole sitemap for 200s, as in G007.
+- Spot-check a quant chapter for regressions.
+- Edge cases: sequence input given letters, 3 digits, or 5; a chapter slug that does not exist.
+
+## Out of Scope
+
+- Reading Comprehension, which already has its own route and player.
+- The DILR and Quant chapters, which are already served and already listed — nothing about them changes here.
+- Intro copy per chapter page (September).
+- Backfilling the 10 missing answer keys, which is a data task.

--- a/src/app/cat-prep/components/PracticeTopicRow.tsx
+++ b/src/app/cat-prep/components/PracticeTopicRow.tsx
@@ -32,8 +32,10 @@ export default function PracticeTopicRow({
     if (chapterSlug === "reading-comprehensions") {
       return `/cat-prep/practice/varc/reading-comprehensions/1`;
     }
-    // Odd One Out, Para Jumbles, Para Summary — same MCQ player via quant route pattern
-    return `/cat-prep/practice/varc/${topicSlug}/${chapterSlug}`;
+    // Odd One Out, Para Jumbles, Para Summary. The topic slug is deliberately absent:
+    // every VARC chapter hangs off one topic, so it added a segment carrying no meaning
+    // — and this used to point at /varc/varc/<chapter>, a route that never existed.
+    return `/cat-prep/practice/varc/${chapterSlug}`;
   }
 
   return (

--- a/src/app/cat-prep/practice/quant/[topic]/[chapter]/QuestionPlayer.tsx
+++ b/src/app/cat-prep/practice/quant/[topic]/[chapter]/QuestionPlayer.tsx
@@ -1,9 +1,8 @@
-// QuestionPlayer — interactive MCQ/jumble question player with cross-session state persistence
+// QuestionPlayer — interactive question player for MCQ and para-jumble sequences, with cross-session state persistence
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PracticeQuestion, PracticeQuestionSolution, OptionsMap } from "@/app/cat-prep/models/practice";
-import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { usePracticeProgress } from "@/app/cat-prep/lib/usePracticeProgress";
 import { PracticeOptionButton, type OptionState } from "@/app/cat-prep/components/practice/PracticeOptionButton";
@@ -11,6 +10,18 @@ import { PracticePalette, type PillState } from "@/app/cat-prep/components/pract
 
 type OptionKey = keyof OptionsMap;
 const OPTION_KEYS: OptionKey[] = ["A", "B", "C", "D"];
+
+// Marks a question checked without matching any real option letter or sequence, for the
+// questions whose answer key is simply missing from the source data (10 Odd One Out).
+const NO_ANSWER_SENTINEL = "—";
+
+// Para Jumbles give four sentences and ask for their order, so the answer is a sequence
+// like "2413" rather than an option. Stored in correct_text; correct_answer is null.
+const JUMBLE_SEQUENCE = /^[1-4]{4}$/;
+
+function isCompleteSequence(value: string): boolean {
+  return JUMBLE_SEQUENCE.test(value) && new Set(value).size === 4;
+}
 
 function DifficultyBadge({ difficulty }: { difficulty: string }) {
   const color =
@@ -72,12 +83,17 @@ export default function QuestionPlayer({
   backLabel: string;
   storageKey: string;
 }) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const initialQ = parseInt(searchParams.get("q") ?? "1", 10);
-  const [currentNum, setCurrentNum] = useState(
-    isNaN(initialQ) || initialQ < 1 || initialQ > questions.length ? 1 : initialQ
-  );
+  // `?q=` is read from the URL after mount rather than through useSearchParams, which is
+  // a dynamic API: using it during render opted this whole subtree out of prerendering,
+  // so every practice chapter page served Googlebot a breadcrumb, a heading and no
+  // questions at all. Starting at question 1 makes the first render deterministic, so the
+  // page prerenders; a deep link still lands on its question immediately after hydration.
+  const [currentNum, setCurrentNum] = useState(1);
+
+  useEffect(() => {
+    const q = parseInt(new URLSearchParams(window.location.search).get("q") ?? "1", 10);
+    if (!isNaN(q) && q >= 1 && q <= questions.length) setCurrentNum(q);
+  }, [questions.length]);
 
   const { answers, correctAnswers, setAnswer, setCorrectAnswer } = usePracticeProgress(storageKey);
   const [sessionSolutions, setSessionSolutions] = useState<Record<number, PracticeQuestionSolution>>({});
@@ -85,32 +101,41 @@ export default function QuestionPlayer({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const question = questions.find((q) => q.question_number === currentNum) ?? questions[0];
-  const selected = question ? ((answers[question.question_number] as OptionKey) ?? null) : null;
+  const isJumble = question?.question_type === "jumble";
+  // For an MCQ this is the chosen letter; for a jumble it is the typed sequence.
+  const given = question ? (answers[question.question_number] ?? null) : null;
+  const selected = isJumble ? null : (given as OptionKey | null);
   const sessionSolution = question ? (sessionSolutions[question.question_number] ?? null) : null;
   const isChecked = question ? !!correctAnswers[question.question_number] : false;
-  const correctLetter = question
-    ? (correctAnswers[question.question_number] as OptionKey | undefined)
-    : undefined;
+  const recordedAnswer = question ? correctAnswers[question.question_number] : undefined;
+  const correctLetter = isJumble ? undefined : (recordedAnswer as OptionKey | undefined);
+  const answerUnavailable = recordedAnswer === NO_ANSWER_SENTINEL;
+  const canCheck = isJumble ? isCompleteSequence(given ?? "") : !!selected;
 
-  const navigateTo = useCallback(
-    (num: number) => {
-      setCurrentNum(num);
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("q", String(num));
-      router.push(`?${params.toString()}`, { scroll: false });
-    },
-    [router, searchParams]
-  );
+  // History is updated directly rather than through the router: this only records which
+  // question is showing, and a router push would re-render the route for a value the
+  // component already holds.
+  const navigateTo = useCallback((num: number) => {
+    setCurrentNum(num);
+    const params = new URLSearchParams(window.location.search);
+    params.set("q", String(num));
+    window.history.replaceState(null, "", `?${params.toString()}`);
+  }, []);
 
   async function checkSolution() {
-    if (!question || !selected) return;
+    if (!question || !canCheck) return;
     setLoading(true);
     try {
       const res = await fetch(`/api/practice/questions/${question._id}/solution`);
       if (res.ok) {
         const data = (await res.json()) as PracticeQuestionSolution;
         setSessionSolutions((prev) => ({ ...prev, [question.question_number]: data }));
-        setCorrectAnswer(question.question_number, data.correct_answer);
+        // A jumble's answer lives in correct_text; the sentinel keeps a question with no
+        // key at all from leaving the user on a button that does nothing.
+        setCorrectAnswer(
+          question.question_number,
+          data.correct_answer ?? data.correct_text ?? NO_ANSWER_SENTINEL
+        );
       }
     } finally {
       setLoading(false);
@@ -119,8 +144,10 @@ export default function QuestionPlayer({
 
   function getPillState(qNum: number): PillState {
     if (qNum === currentNum) return "current";
-    const cl = correctAnswers[qNum] as OptionKey | undefined;
-    const ans = answers[qNum] as OptionKey | undefined;
+    const cl = correctAnswers[qNum];
+    const ans = answers[qNum];
+    // A question we could never grade counts as attempted, not as wrong.
+    if (cl === NO_ANSWER_SENTINEL) return "answered";
     if (cl && ans) return ans === cl ? "correct" : "wrong";
     if (ans) return "answered";
     return "unanswered";
@@ -129,7 +156,9 @@ export default function QuestionPlayer({
   if (!question) return null;
 
   const optionState = (key: OptionKey): OptionState => {
-    if (correctLetter) {
+    // With no key to grade against, the choice stays merely selected — marking it wrong
+    // would be asserting something we don't know.
+    if (correctLetter && !answerUnavailable) {
       if (key === correctLetter) return "correct";
       if (key === selected) return "wrong";
       return "idle";
@@ -186,36 +215,119 @@ export default function QuestionPlayer({
               <MathContent html={question.question} containerRef={containerRef} />
             </div>
 
-            {/* Options */}
-            <div>
-              {OPTION_KEYS.map((key) => (
-                <PracticeOptionButton
-                  key={key}
-                  label={key}
-                  state={optionState(key)}
-                  disabled={isChecked}
-                  onClick={() => !isChecked && setAnswer(question.question_number, key)}
+            {/* Answer area — options for an MCQ, ordered sentences plus a sequence for a jumble */}
+            {isJumble ? (
+              <div>
+                <ol style={{ listStyle: "none", padding: 0, margin: "0 0 18px" }}>
+                  {OPTION_KEYS.map((key, i) => (
+                    <li
+                      key={key}
+                      style={{
+                        display: "flex",
+                        gap: 10,
+                        padding: "10px 14px",
+                        borderRadius: 10,
+                        border: "1.5px solid #E2E8F0",
+                        marginBottom: 8,
+                        fontSize: 14,
+                        color: "#334155",
+                        lineHeight: 1.7,
+                      }}
+                    >
+                      <span className="font-bold" style={{ color: "#0F766E", flexShrink: 0 }}>{i + 1}.</span>
+                      <span style={{ minWidth: 0 }}>
+                        <MathContent html={question.options[key]} containerRef={containerRef} />
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+
+                <label
+                  htmlFor="jumble-sequence"
+                  style={{ display: "block", fontSize: 13, color: "#64748B", marginBottom: 6, fontWeight: 600 }}
                 >
-                  <MathContent html={question.options[key]} containerRef={containerRef} />
-                </PracticeOptionButton>
-              ))}
-            </div>
+                  Enter the correct order (e.g. 2413)
+                </label>
+                <input
+                  id="jumble-sequence"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  maxLength={4}
+                  value={given ?? ""}
+                  disabled={isChecked}
+                  // Only digits 1-4 are meaningful, so anything else never reaches state.
+                  onChange={(e) => {
+                    const next = e.target.value.replace(/[^1-4]/g, "").slice(0, 4);
+                    setAnswer(question.question_number, next);
+                  }}
+                  style={{
+                    width: 140,
+                    padding: "10px 14px",
+                    borderRadius: 10,
+                    border: `1.5px solid ${isChecked ? "#E2E8F0" : "#CBD5E1"}`,
+                    background: isChecked ? "#F8FAFC" : "#fff",
+                    color: "#1E3A5F",
+                    fontSize: 18,
+                    fontWeight: 700,
+                    letterSpacing: "6px",
+                    fontFamily: "inherit",
+                    outline: "none",
+                  }}
+                />
+
+                {isChecked && (
+                  <p
+                    className="font-bold"
+                    style={{
+                      marginTop: 10,
+                      fontSize: 13,
+                      color: answerUnavailable ? "#92400E" : given === recordedAnswer ? "#065F46" : "#991B1B",
+                    }}
+                  >
+                    {answerUnavailable
+                      ? "The answer key is missing for this question."
+                      : given === recordedAnswer
+                        ? "Correct"
+                        : `Incorrect — correct order: ${recordedAnswer}`}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div>
+                {OPTION_KEYS.map((key) => (
+                  <PracticeOptionButton
+                    key={key}
+                    label={key}
+                    state={optionState(key)}
+                    disabled={isChecked}
+                    onClick={() => !isChecked && setAnswer(question.question_number, key)}
+                  >
+                    <MathContent html={question.options[key]} containerRef={containerRef} />
+                  </PracticeOptionButton>
+                ))}
+                {isChecked && answerUnavailable && (
+                  <p className="font-bold" style={{ marginTop: 10, fontSize: 13, color: "#92400E" }}>
+                    The answer key is missing for this question.
+                  </p>
+                )}
+              </div>
+            )}
 
             {/* Check Solution button — hidden once checked in any session */}
             {!isChecked && (
               <button
                 onClick={checkSolution}
-                disabled={!selected || loading}
+                disabled={!canCheck || loading}
                 style={{
                   marginTop: 8,
                   padding: "11px 24px",
                   borderRadius: 10,
                   border: "none",
-                  background: selected ? "#1E3A5F" : "#E2E8F0",
-                  color: selected ? "#fff" : "#94A3B8",
+                  background: canCheck ? "#1E3A5F" : "#E2E8F0",
+                  color: canCheck ? "#fff" : "#94A3B8",
                   fontSize: 14,
                   fontWeight: 700,
-                  cursor: selected ? "pointer" : "not-allowed",
+                  cursor: canCheck ? "pointer" : "not-allowed",
                   fontFamily: "inherit",
                   transition: "all 0.18s",
                 }}

--- a/src/app/cat-prep/practice/varc/[chapter]/page.tsx
+++ b/src/app/cat-prep/practice/varc/[chapter]/page.tsx
@@ -1,0 +1,131 @@
+import { Suspense } from "react";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { fetchPracticeQuestions } from "@/lib/practiceQueries";
+import { PRACTICE_SUBJECTS } from "@/constants/practiceChapters";
+import { JsonLd } from "@/app/components/JsonLd";
+import { ENV } from "@/config/env";
+import { buildLearningResourceSchema } from "@/app/cat-prep/lib/nodeMetadata";
+import QuestionPlayer from "@/app/cat-prep/practice/quant/[topic]/[chapter]/QuestionPlayer";
+
+type Props = { params: Promise<{ chapter: string }> };
+
+// Reading Comprehension has its own route a level deeper, so it is excluded here and
+// redirected instead of 404ing when someone lands on the bare chapter URL.
+const RC_SLUG = "reading-comprehensions";
+
+function varcChapters() {
+  const subject = PRACTICE_SUBJECTS.find((s) => s.section === "VARC");
+  return (subject?.topics.flatMap((t) => t.chapters) ?? []).filter((c) => c.slug !== RC_SLUG);
+}
+
+export function generateStaticParams() {
+  return varcChapters().map((c) => ({ chapter: c.slug }));
+}
+
+function resolveChapter(slug: string) {
+  return varcChapters().find((c) => c.slug === slug);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { chapter: slug } = await params;
+  const chapter = resolveChapter(slug);
+  if (!chapter) return { title: "VARC Practice" };
+  const title = `CAT ${chapter.name} Practice with Solutions`;
+  const description = `Practise ${chapter.questionCount} CAT-level ${chapter.name.toLowerCase()} questions for VARC, each with a detailed explanation. Free, no sign-up needed.`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `${ENV.SITE_URL}/cat-prep/practice/varc/${slug}` },
+    openGraph: { title, description },
+    twitter: { title, description },
+  };
+}
+
+export default async function VarcChapterPage({ params }: Props) {
+  const { chapter: slug } = await params;
+
+  if (slug === RC_SLUG) redirect(`/cat-prep/practice/varc/${RC_SLUG}/1`);
+
+  const chapter = resolveChapter(slug);
+  if (!chapter) notFound();
+
+  // These chapters are stored with topic equal to chapter — unlike Quant, where the
+  // topic is a real grouping — so the chapter name is passed for both.
+  const questions = await fetchPracticeQuestions("VARC", chapter.name, chapter.name);
+  if (!questions.length) notFound();
+
+  const pageUrl = `${ENV.SITE_URL}/cat-prep/practice/varc/${slug}`;
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "CAT Prep", item: `${ENV.SITE_URL}/cat-prep` },
+        { "@type": "ListItem", position: 2, name: "Practice", item: `${ENV.SITE_URL}/cat-prep/practice` },
+        { "@type": "ListItem", position: 3, name: `${chapter.name} Practice`, item: pageUrl },
+      ],
+    },
+    buildLearningResourceSchema(
+      `CAT ${chapter.name} Practice`,
+      `Practise ${chapter.questionCount} CAT-level ${chapter.name.toLowerCase()} questions for VARC, each with a detailed explanation.`,
+      pageUrl
+    ),
+    {
+      "@context": "https://schema.org",
+      "@type": "Quiz",
+      name: `CAT ${chapter.name} Practice`,
+      educationalLevel: "graduate",
+      about: { "@type": "Thing", name: "CAT Exam" },
+      provider: { "@type": "Organization", name: "StudyNaksha", url: ENV.SITE_URL },
+      numberOfQuestions: questions.length,
+    },
+  ];
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <div style={{ minHeight: "100vh", background: "#FFFDF8" }}>
+        <div
+          style={{
+            background: "linear-gradient(160deg, #F0FDFA 0%, #EEF2FF 100%)",
+            padding: "24px 24px 28px",
+          }}
+        >
+          <div style={{ maxWidth: 960, margin: "0 auto" }}>
+            <div style={{ fontSize: 12, color: "#94A3B8", marginBottom: 6 }}>
+              <Link href="/cat-prep" style={{ color: "#94A3B8", textDecoration: "none" }}>
+                CAT Prep
+              </Link>
+              {" / "}
+              <span style={{ color: "#64748B" }}>Practice</span>
+              {" / "}
+              <span style={{ color: "#64748B" }}>VARC</span>
+              {" / "}
+              <span style={{ color: "#0F766E", fontWeight: 600 }}>{chapter.name}</span>
+            </div>
+            <h1
+              className="font-extrabold"
+              style={{ fontSize: "clamp(20px,3vw,28px)", margin: 0, color: "#0F766E", letterSpacing: "-0.3px" }}
+            >
+              {chapter.name}
+            </h1>
+            <p style={{ fontSize: 13, color: "#64748B", marginTop: 4, marginBottom: 0 }}>
+              VARC · {questions.length} questions with explanations
+            </p>
+          </div>
+        </div>
+
+        <Suspense>
+          <QuestionPlayer
+            questions={questions}
+            backHref="/cat-prep"
+            backLabel="Back to Roadmap"
+            storageKey={`varc-${slug}`}
+          />
+        </Suspense>
+      </div>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -99,6 +99,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // They stay prerendered and reachable from the archive for people; they just aren't
   // put forward for indexing.
 
+  // Para Jumbles, Para Summary and Odd One Out. Reading Comprehension is excluded — its
+  // questions live in another collection and it has its own per-passage route below.
+  const varcSubject = PRACTICE_SUBJECTS.find((s) => s.section === "VARC");
+  const varcEntries: MetadataRoute.Sitemap = (varcSubject?.topics.flatMap((t) => t.chapters) ?? [])
+    .filter((chapter) => chapter.slug !== "reading-comprehensions")
+    .map((chapter) => ({
+      url: `${ENV.SITE_URL}/cat-prep/practice/varc/${chapter.slug}`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }));
+
   const rcEntries: MetadataRoute.Sitemap = Array.from({ length: rcCount }, (_, i) => ({
     url: `${ENV.SITE_URL}/cat-prep/practice/varc/reading-comprehensions/${i + 1}`,
     lastModified: now,
@@ -128,6 +140,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...subtopicEntries,
     ...quantEntries,
     ...dilrEntries,
+    ...varcEntries,
     ...rcEntries,
   ];
 }


### PR DESCRIPTION
> **Stacked on #40.** Base is `feat/seo-coverage-keywords`, so the diff stays clean — both branches touch `sitemap.ts`. Merge #40 first and GitHub will retarget this to `staging`.

## 1. 150 CAT questions had no page

`percentyl_practice_questions` holds three VARC chapters — Para Jumbles, Para Summary, Odd One Out, 50 questions each — and the only practice route filtered on `section: "Quant"`.

Worse than invisible: `PracticeTopicRow.tsx:36` already built `/cat-prep/practice/varc/<topic>/<chapter>`, so **all three roadmap chips led a real user to a 404.** Same defect as the three quant chapters in #40, found the same way.

New route at `/cat-prep/practice/varc/[chapter]`. One segment, not two — every VARC chapter hangs off a single topic, so the topic slug carried no meaning and would have produced `/varc/varc/para-jumbles`. The bare `/varc/reading-comprehensions` redirects to `/1` rather than 404ing.

### What the data forced

| Chapter | Type | Answer field |
|---|---|---|
| Para Summary | `mcq` | `correct_answer` — A–D |
| Odd One Out | `mcq` | A–D on 40, **null on 10** |
| Para Jumbles | `jumble` | `correct_text` — a 4-digit sequence like `2413` |

**Para Jumbles are not multiple choice.** The four options are the sentences; the answer is their order. They render as a numbered list with a sequence input, the way CAT actually asks them.

**Ten Odd One Out questions have no answer key at all** — both fields null. Checking one now says so rather than leaving a dead button, and the chosen option is *not* marked wrong, because we don't know that it is.

Extended `QuestionPlayer` rather than copying it — palette, navigation, progress, MathJax and solution fetching are identical, only the answer widget differs. Quant pages are unchanged.

## 2. The bigger find: practice pages served Googlebot nothing

While verifying the new pages I checked what the *existing* ones actually return:

```
/cat-prep/practice/quant/algebra/functions  →  117 characters of visible text
```

A breadcrumb, a heading, zero questions. `QuestionPlayer` called `useSearchParams()` during render to read the `?q=` deep link — a dynamic API, which opted the entire subtree out of prerendering. The static HTML was the Suspense fallback.

**92 pages already in your sitemap returned 200 with nothing to index.** It's the PYQ sign-in wall wearing a different hat: the page is reachable, it just has no content.

Fixed by making the first render deterministic — initial question is 1, `?q=` is read from `window.location` after mount, so deep links still work. Navigation writes history directly instead of pushing through the router, which only ever re-rendered the route for a value the component already held.

Visible text per page, measured on the production build:

| Page | Before | After |
|---|---|---|
| `quant/algebra/functions` | 117 | **440** |
| `dilr/bar-graphs/3` | 117 | **1,032** |
| `varc/para-jumbles` | — | **2,134** |

## Verified

- All three new pages return 200 and render 50 questions each
- Para Jumbles shows the numbered sentences and the sequence input; Para Summary shows A–D and no sequence input
- `/varc/reading-comprehensions` → **307** to `/1`
- Sitemap **212 → 215**, zero duplicates, **all 215 return 200**
- Deep link `?q=7` still resolves
- RC pages (dynamic) still serve 3,377 characters
- `tsc` clean, `vitest` 31 pass, `next build` 217 static pages
- Lint unchanged at the 8 pre-existing errors in `how-to-prepare`

## Worth knowing

- The **10 answer-less Odd One Out questions** are a data gap, not a code one. Backfilling them is a separate task.
- Every practice page now server-renders **question 1 only** — a real improvement over nothing, but not the whole chapter. Server-rendering all 20–50 questions per chapter, as the PYQ reader does, is the larger win and deserves its own spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)